### PR TITLE
fixed issue #13

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,1 @@
-.. include:: ../README.rst
+.. include:: ../README.rst 

--- a/tests/test_eppyhelpers/test_extfields.py
+++ b/tests/test_eppyhelpers/test_extfields.py
@@ -271,41 +271,51 @@ IDF.setiddname(StringIO(iddtxt))
 def test_extensiblefields2list():
     """py.test for extensiblefields2list"""
     tdata = ((
-        "branchlist",
+        "branchlist", False,
         [
             "Heating Supply Inlet Branch",
             "Central Boiler Branch",
             "Heating Supply Bypass Branch",
             "Heating Supply Outlet Branch"
-        ]),  # idfkey, expected
+        ]),  # idfkey, nested, expected
         (
-        "BuildingSurface:Detailed",
+        "BuildingSurface:Detailed", False,
         [
             0.0, 0.0, 3.0,
             0.0, 0.0, 2.4,
             30.5, 0.0, 2.4,
             30.5, 0.0, 3.0
-        ]),  # idfkey, expected
+        ]),  # idfkey, nested, expected
         (
-        "version", None),  # idfkey, expected
+        "BuildingSurface:Detailed", True,
+        [
+            (0.0, 0.0, 3.0),
+            (0.0, 0.0, 2.4),
+            (30.5, 0.0, 2.4),
+            (30.5, 0.0, 3.0)
+        ]),  # idfkey, nested, expected
+        (
+        "version", False, None),  # idfkey, nested, expected
     )
-    for idfkey, expected in tdata:
+    for idfkey, nested, expected in tdata:
         idf = IDF(StringIO(idftxt))
         idfobject = idf.idfobjects[idfkey.upper()][0]
-        result = extfields.extensiblefields2list(idfobject)
+        result = extfields.extensiblefields2list(idfobject, nested=nested)
         assert result == expected
 
 
 def test_list2extensiblefields():
     """py.test for list2extensiblefields"""
     tdata = (
-        ("branchlist", [11, 22, 33], [11, 22, 33]),  # idfkey, nlst, expected
+        ("branchlist", [11, 22, 33], False, [11, 22, 33]),  # idfkey, nlst, nested, expected
         ("BuildingSurface:Detailed",
-            [11, 22, 33], [11, 22, 33]),  # idfkey, nlst, expected
+            [11, 22, 33], False, [11, 22, 33]),  # idfkey, nlst, nested, expected
+        ("BuildingSurface:Detailed",
+            [(1,2,3),(11, 22, 33)], True, [(1,2,3), (11, 22, 33)]),  # idfkey, nlst, nested, expected
     )
-    for idfkey, nlst, expected in tdata:
+    for idfkey, nlst, nested, expected in tdata:
         idf = IDF(StringIO(idftxt))
         idfobject = idf.idfobjects[idfkey.upper()][0]
-        extfields.list2extensiblefields(idfobject, nlst)
-        result = extfields.extensiblefields2list(idfobject)
+        extfields.list2extensiblefields(idfobject, nlst, nested=nested)
+        result = extfields.extensiblefields2list(idfobject, nested=nested)
         assert result == expected

--- a/tests/test_eppyhelpers/test_extfields.py
+++ b/tests/test_eppyhelpers/test_extfields.py
@@ -271,40 +271,44 @@ IDF.setiddname(StringIO(iddtxt))
 def test_extensiblefields2list():
     """py.test for extensiblefields2list"""
     tdata = (
-    (
-        "branchlist", False,
-        [
-            "Heating Supply Inlet Branch",
-            "Central Boiler Branch",
-            "Heating Supply Bypass Branch",
-            "Heating Supply Outlet Branch"
-        ]),  # idfkey, nested, expected
         (
-        "BuildingSurface:Detailed", False,
-        [
-            0.0, 0.0, 3.0,
-            0.0, 0.0, 2.4,
-            30.5, 0.0, 2.4,
-            30.5, 0.0, 3.0
-        ]),  # idfkey, nested, expected
+            "branchlist", False,
+            [
+                "Heating Supply Inlet Branch",
+                "Central Boiler Branch",
+                "Heating Supply Bypass Branch",
+                "Heating Supply Outlet Branch"
+            ]
+        ),  # idfkey, nested, expected
         (
-        "BuildingSurface:Detailed", True,
-        [
-            (0.0, 0.0, 3.0),
-            (0.0, 0.0, 2.4),
-            (30.5, 0.0, 2.4),
-            (30.5, 0.0, 3.0)
-        ]),  # idfkey, nested, expected
-    (
-        "branchlist", True,
-        [
-            "Heating Supply Inlet Branch",
-            "Central Boiler Branch",
-            "Heating Supply Bypass Branch",
-            "Heating Supply Outlet Branch"
-        ]),  # idfkey, nested, expected
+            "BuildingSurface:Detailed", False,
+            [
+                0.0, 0.0, 3.0,
+                0.0, 0.0, 2.4,
+                30.5, 0.0, 2.4,
+                30.5, 0.0, 3.0
+            ]
+        ),  # idfkey, nested, expected
         (
-        "version", False, None),  # idfkey, nested, expected
+            "BuildingSurface:Detailed", True,
+            [
+                (0.0, 0.0, 3.0),
+                (0.0, 0.0, 2.4),
+                (30.5, 0.0, 2.4),
+                (30.5, 0.0, 3.0)
+            ]
+        ),  # idfkey, nested, expected
+        (
+            "branchlist", True,
+            [
+                "Heating Supply Inlet Branch",
+                "Central Boiler Branch",
+                "Heating Supply Bypass Branch",
+                "Heating Supply Outlet Branch"
+            ]
+        ),  # idfkey, nested, expected
+        (
+            "version", False, None),  # idfkey, nested, expected
     )
     for idfkey, nested, expected in tdata:
         idf = IDF(StringIO(idftxt))
@@ -316,12 +320,16 @@ def test_extensiblefields2list():
 def test_list2extensiblefields():
     """py.test for list2extensiblefields"""
     tdata = (
-        ("branchlist", ["11", "22", "33"], False, ["11", "22", "33"]),  # idfkey, nlst, nested, expected
+        ("branchlist", ["11", "22", "33"], False,
+            ["11", "22", "33"]),  # idfkey, nlst, nested, expected
         ("BuildingSurface:Detailed",
-            [11, 22, 33], False, [11, 22, 33]),  # idfkey, nlst, nested, expected
+            [11, 22, 33], False,
+            [11, 22, 33]),  # idfkey, nlst, nested, expected
         ("BuildingSurface:Detailed",
-            [(1,2,3),(11, 22, 33)], True, [(1,2,3), (11, 22, 33)]),  # idfkey, nlst, nested, expected
-        ("branchlist", ["11", "22", "33"], True, ["11", "22", "33"]),  # idfkey, nlst, nested, expected
+            [(1, 2, 3), (11, 22, 33)],
+            True, [(1, 2, 3), (11, 22, 33)]),  # idfkey, nlst, nested, expected
+        ("branchlist", ["11", "22", "33"],
+            True, ["11", "22", "33"]),  # idfkey, nlst, nested, expected
     )
     for idfkey, nlst, nested, expected in tdata:
         idf = IDF(StringIO(idftxt))

--- a/tests/test_eppyhelpers/test_extfields.py
+++ b/tests/test_eppyhelpers/test_extfields.py
@@ -320,20 +320,26 @@ def test_extensiblefields2list():
 def test_list2extensiblefields():
     """py.test for list2extensiblefields"""
     tdata = (
-        ("branchlist", ["11", "22", "33"], False,
-            ["11", "22", "33"]),  # idfkey, nlst, nested, expected
+        ("branchlist", ["11", "22", "33"],
+            ["11", "22", "33"]),  # idfkey, nlst, expected
         ("BuildingSurface:Detailed",
-            [11, 22, 33], False,
-            [11, 22, 33]),  # idfkey, nlst, nested, expected
+            [11, 22, 33, 1, 2, 3],
+            [(11, 22, 33), (1, 2, 3)]),  # idfkey, nlst, expected
         ("BuildingSurface:Detailed",
             [(1, 2, 3), (11, 22, 33)],
-            True, [(1, 2, 3), (11, 22, 33)]),  # idfkey, nlst, nested, expected
+            [(1, 2, 3), (11, 22, 33)]),  # idfkey, nlst, expected
+        ("BuildingSurface:Detailed",
+            [(1, 2, 3), (11, 22, 33)],
+            [(1, 2, 3), (11, 22, 33)]),  # idfkey, nlst, expected
+        ("BuildingSurface:Detailed",
+            [(1, 2, 3), (11, 22, 33)],
+            [(1, 2, 3), (11, 22, 33)]),  # idfkey, nlst, expected
         ("branchlist", ["11", "22", "33"],
-            True, ["11", "22", "33"]),  # idfkey, nlst, nested, expected
+            ["11", "22", "33"]),  # idfkey, nlst, expected
     )
-    for idfkey, nlst, nested, expected in tdata:
+    for idfkey, nlst, expected in tdata:
         idf = IDF(StringIO(idftxt))
         idfobject = idf.idfobjects[idfkey.upper()][0]
-        extfields.list2extensiblefields(idfobject, nlst, nested=nested)
-        result = extfields.extensiblefields2list(idfobject, nested=nested)
+        extfields.list2extensiblefields(idfobject, nlst)
+        result = extfields.extensiblefields2list(idfobject, nested=True)
         assert result == expected

--- a/tests/test_eppyhelpers/test_extfields.py
+++ b/tests/test_eppyhelpers/test_extfields.py
@@ -237,7 +237,128 @@ N25, \\field Vertex 8 Y-coordinate
    \\units m
 N26; \\field Vertex 8 Z-coordinate
    \\units m
-   \\type real"""  # noqa: E501
+   \\type real
+
+Schedule:Week:Compact,
+  \\extensible:2 - repeat last two fields, remembering to remove ; from "inner" fields.
+  \\memo Compact definition for Schedule:Day:List
+  \\min-fields 3
+  A1 , \\field Name
+       \\required-field
+       \\reference WeekScheduleNames
+       \\type alpha
+  A2 , \\field DayType List 1
+       \\begin-extensible
+       \\note "For" is an optional prefix/start of the For fields.  Choices can be combined on single line
+       \\note if separated by spaces. i.e. "Holiday Weekends"
+       \\note Should have a space after For, if it is included. i.e. "For Alldays"
+       \\required-field
+       \\type choice
+       \\key AllDays
+       \\key AllOtherDays
+       \\key Weekdays
+       \\key Weekends
+       \\key Sunday
+       \\key Monday
+       \\key Tuesday
+       \\key Wednesday
+       \\key Thursday
+       \\key Friday
+       \\key Saturday
+       \\key Holiday
+       \\key SummerDesignDay
+       \\key WinterDesignDay
+       \\key CustomDay1
+       \\key CustomDay2
+  A3 , \\field Schedule:Day Name 1
+       \\required-field
+       \\type object-list
+       \\object-list DayScheduleNames
+  A4 , \\field DayType List 2
+       \\type choice
+       \\key AllDays
+       \\key AllOtherDays
+       \\key Weekdays
+       \\key Weekends
+       \\key Sunday
+       \\key Monday
+       \\key Tuesday
+       \\key Wednesday
+       \\key Thursday
+       \\key Friday
+       \\key Saturday
+       \\key Holiday
+       \\key SummerDesignDay
+       \\key WinterDesignDay
+       \\key CustomDay1
+       \\key CustomDay2
+  A5 , \\field Schedule:Day Name 2
+       \\type object-list
+       \\object-list DayScheduleNames
+  A6 , \\field DayType List 3
+       \\type choice
+       \\key AllDays
+       \\key AllOtherDays
+       \\key Weekdays
+       \\key Weekends
+       \\key Sunday
+       \\key Monday
+       \\key Tuesday
+       \\key Wednesday
+       \\key Thursday
+       \\key Friday
+       \\key Saturday
+       \\key Holiday
+       \\key SummerDesignDay
+       \\key WinterDesignDay
+       \\key CustomDay1
+       \\key CustomDay2
+  A7 , \\field Schedule:Day Name 3
+       \\type object-list
+       \\object-list DayScheduleNames
+  A8 , \\field DayType List 4
+       \\type choice
+       \\key AllDays
+       \\key AllOtherDays
+       \\key Weekdays
+       \\key Weekends
+       \\key Sunday
+       \\key Monday
+       \\key Tuesday
+       \\key Wednesday
+       \\key Thursday
+       \\key Friday
+       \\key Saturday
+       \\key Holiday
+       \\key SummerDesignDay
+       \\key WinterDesignDay
+       \\key CustomDay1
+       \\key CustomDay2
+  A9 , \\field Schedule:Day Name 4
+       \\type object-list
+       \\object-list DayScheduleNames
+  A10, \\field DayType List 5
+       \\type choice
+       \\key AllDays
+       \\key AllOtherDays
+       \\key Weekdays
+       \\key Weekends
+       \\key Sunday
+       \\key Monday
+       \\key Tuesday
+       \\key Wednesday
+       \\key Thursday
+       \\key Friday
+       \\key Saturday
+       \\key Holiday
+       \\key SummerDesignDay
+       \\key WinterDesignDay
+       \\key CustomDay1
+       \\key CustomDay2
+  A11; \\field Schedule:Day Name 5
+       \\type object-list
+       \\object-list DayScheduleNames
+"""  # noqa: E501
 
 idftxt = """Version,8.9;
 
@@ -315,6 +436,12 @@ def test_extensiblefields2list():
         idfobject = idf.idfobjects[idfkey.upper()][0]
         result = extfields.extensiblefields2list(idfobject, nested=nested)
         assert result == expected
+    # test for edge conditions
+    # there no values in the extensible fields
+    key = "Schedule:Week:Compact".upper()
+    idfobject = idf.newidfobject(key)
+    result = extfields.extensiblefields2list(idfobject)
+    assert result == []
 
 
 def test_list2extensiblefields():
@@ -343,3 +470,32 @@ def test_list2extensiblefields():
         extfields.list2extensiblefields(idfobject, nlst)
         result = extfields.extensiblefields2list(idfobject, nested=True)
         assert result == expected
+    # test for edge conditions
+    # there no values in the extensible fields
+    # and the field just before begin-extensible field has no value
+    key = "Schedule:Week:Compact".upper()
+    idfobject = idf.newidfobject(key)
+    nlst = [1, 2, 3, 4]
+    expected = [1, 2, 3, 4]
+    extfields.list2extensiblefields(idfobject, nlst)
+    result = extfields.extensiblefields2list(idfobject, nested=False)
+    assert result == expected
+
+
+def extendlist():
+    """py.test for extendlist"""
+    tdata = (
+        ([1, 2, 3], 5, "", [1, 2, 3, "", ""]),  # lst, size, fillwith, expected
+        ([1, 2, 3], 3, "", [1, 2, 3]),  # lst, size, fillwith, expected
+        ([1, 2, 3], 2, "", [1, 2, 3]),  # lst, size, fillwith, expected
+    )
+    for lst, size, fillwith, expected in tdata:
+        result = extfields.extendlist(lst, size, fillwith=fillwith)
+        assert result == expected
+
+
+def test_grouper():
+    """py.test for grouper"""
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx""
+    result = list(extfields.grouper([1, 2, 3, 4, 5, 6, 7], 3, 9))
+    assert result == [(1, 2, 3), (4, 5, 6), (7, 9, 9)]

--- a/tests/test_eppyhelpers/test_extfields.py
+++ b/tests/test_eppyhelpers/test_extfields.py
@@ -270,7 +270,8 @@ IDF.setiddname(StringIO(iddtxt))
 
 def test_extensiblefields2list():
     """py.test for extensiblefields2list"""
-    tdata = ((
+    tdata = (
+    (
         "branchlist", False,
         [
             "Heating Supply Inlet Branch",
@@ -294,6 +295,14 @@ def test_extensiblefields2list():
             (30.5, 0.0, 2.4),
             (30.5, 0.0, 3.0)
         ]),  # idfkey, nested, expected
+    (
+        "branchlist", True,
+        [
+            "Heating Supply Inlet Branch",
+            "Central Boiler Branch",
+            "Heating Supply Bypass Branch",
+            "Heating Supply Outlet Branch"
+        ]),  # idfkey, nested, expected
         (
         "version", False, None),  # idfkey, nested, expected
     )
@@ -307,11 +316,12 @@ def test_extensiblefields2list():
 def test_list2extensiblefields():
     """py.test for list2extensiblefields"""
     tdata = (
-        ("branchlist", [11, 22, 33], False, [11, 22, 33]),  # idfkey, nlst, nested, expected
+        ("branchlist", ["11", "22", "33"], False, ["11", "22", "33"]),  # idfkey, nlst, nested, expected
         ("BuildingSurface:Detailed",
             [11, 22, 33], False, [11, 22, 33]),  # idfkey, nlst, nested, expected
         ("BuildingSurface:Detailed",
             [(1,2,3),(11, 22, 33)], True, [(1,2,3), (11, 22, 33)]),  # idfkey, nlst, nested, expected
+        ("branchlist", ["11", "22", "33"], True, ["11", "22", "33"]),  # idfkey, nlst, nested, expected
     )
     for idfkey, nlst, nested, expected in tdata:
         idf = IDF(StringIO(idftxt))

--- a/witheppy/eppyhelpers/extfields.py
+++ b/witheppy/eppyhelpers/extfields.py
@@ -41,6 +41,11 @@ def extensiblefields2list(idfobject, nested=True):
     remove etc. This list can be put back in the idfobject by using the
     function list2extensiblefields(...)
 
+    if nested=True, a nested list will be returned.
+    With nested=True, BUILDINGSURFACE:DETAILED will return
+    [(1,2,3),(2,3,4),(3,4,5)]. With nested=False, it will return
+    [1,2,3,2,3,4,3,4,5]
+
     Parameters
     ----------
     idfobject : eppy.bunch_subclass.EpBunch
@@ -63,7 +68,7 @@ def extensiblefields2list(idfobject, nested=True):
         return None
 
 
-def list2extensiblefields(idfobject, lst, nested=True):
+def list2extensiblefields(idfobject, lst):
     """Replaces the items in the extensible fields with items in lst
 
     This function is a counterpart to the function extensiblefields2list().
@@ -84,8 +89,7 @@ def list2extensiblefields(idfobject, lst, nested=True):
         the idfobject is changed in place and returned by the function
     """
     start = iddhelpers.beginextensible_at(idfobject.objidd)
-    ext_n = iddhelpers.hasextensible(idfobject.objidd)
-    if nested and ext_n > 1:
+    if any(isinstance(item, (list, tuple)) for item in lst):
         ulst = list(chain.from_iterable(lst))  # unpack nesting
     else:
         ulst = lst

--- a/witheppy/eppyhelpers/extfields.py
+++ b/witheppy/eppyhelpers/extfields.py
@@ -15,7 +15,6 @@ from __future__ import unicode_literals
 
 # TODO : update the docstrings for nested=True
 # TODO : run lint
-# TODO : will fail on branchlist if nested=True
 
 # from six import StringIO
 # from six import string_types
@@ -54,8 +53,8 @@ def extensiblefields2list(idfobject, nested=True):
     if iddhelpers.hasextensible(idfobject.objidd):
         start = iddhelpers.beginextensible_at(idfobject.objidd)
         extvalues = idfobject.fieldvalues[start:]
-        if nested:
-            ext_n = iddhelpers.hasextensible(idfobject.objidd)
+        ext_n = iddhelpers.hasextensible(idfobject.objidd)
+        if nested and ext_n>1:
             return list(grouper(extvalues, ext_n))
         else:
             return extvalues
@@ -84,7 +83,8 @@ def list2extensiblefields(idfobject, lst, nested=True):
         the idfobject is changed in place and returned by the function
     """
     start = iddhelpers.beginextensible_at(idfobject.objidd)
-    if nested:
+    ext_n = iddhelpers.hasextensible(idfobject.objidd)
+    if nested and ext_n>1:
         ulst = list(chain.from_iterable(lst))  # unpack nesting
     else:
         ulst = lst

--- a/witheppy/eppyhelpers/extfields.py
+++ b/witheppy/eppyhelpers/extfields.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 
 # from six import StringIO
 # from six import string_types
+
 from witheppy.eppyhelpers import iddhelpers
 
 from itertools import chain
@@ -27,10 +28,18 @@ except ImportError as e:
 
 
 def grouper(iterable, n, fillvalue=None):
-    "Collect data into fixed-length chunks or blocks"
-    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    """Collect data into fixed-length chunks or blocks
+
+    from https://docs.python.org/2/library/itertools.html#recipes
+    grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"""
     args = [iter(iterable)] * n
     return zip_longest(*args, fillvalue=fillvalue)
+
+
+def extendlist(lst, size, fillwith=''):
+    """extend a list to length size using fillwith"""
+    blank = [None] * size
+    return [i for i, j in list(zip_longest(lst, blank, fillvalue=fillwith))]
 
 
 def extensiblefields2list(idfobject, nested=True):
@@ -54,7 +63,7 @@ def extensiblefields2list(idfobject, nested=True):
     Returns
     -------
     list
-        all the extended field values as a list
+        all the extended field values as a flat list or a nested list
     """
     if iddhelpers.hasextensible(idfobject.objidd):
         start = iddhelpers.beginextensible_at(idfobject.objidd)
@@ -93,5 +102,11 @@ def list2extensiblefields(idfobject, lst):
         ulst = list(chain.from_iterable(lst))  # unpack nesting
     else:
         ulst = lst
-    idfobject.obj = idfobject.obj[:start] + ulst
+    #
+    # in case the fieldvalues don't extend upto begin-extensible
+    fieldvalues = extendlist(idfobject.fieldvalues, start+1)
+    #
+    idfobject.obj = fieldvalues[:start] + ulst
+    # cannot assign to idfobject.fieldvalues, since it is readonly
+    #
     return idfobject

--- a/witheppy/eppyhelpers/extfields.py
+++ b/witheppy/eppyhelpers/extfields.py
@@ -26,11 +26,13 @@ try:
 except ImportError as e:
     from itertools import izip_longest as zip_longest
 
+
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
     # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
     args = [iter(iterable)] * n
     return zip_longest(*args, fillvalue=fillvalue)
+
 
 def extensiblefields2list(idfobject, nested=True):
     """returns extensible fields of idfobject as a list
@@ -54,7 +56,7 @@ def extensiblefields2list(idfobject, nested=True):
         start = iddhelpers.beginextensible_at(idfobject.objidd)
         extvalues = idfobject.fieldvalues[start:]
         ext_n = iddhelpers.hasextensible(idfobject.objidd)
-        if nested and ext_n>1:
+        if nested and ext_n > 1:
             return list(grouper(extvalues, ext_n))
         else:
             return extvalues
@@ -84,7 +86,7 @@ def list2extensiblefields(idfobject, lst, nested=True):
     """
     start = iddhelpers.beginextensible_at(idfobject.objidd)
     ext_n = iddhelpers.hasextensible(idfobject.objidd)
-    if nested and ext_n>1:
+    if nested and ext_n > 1:
         ulst = list(chain.from_iterable(lst))  # unpack nesting
     else:
         ulst = lst

--- a/witheppy/eppyhelpers/extfields.py
+++ b/witheppy/eppyhelpers/extfields.py
@@ -12,6 +12,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+
+# TODO : update the docstrings for nested=True
+# TODO : run lint
+# TODO : will fail on branchlist if nested=True
+
 # from six import StringIO
 # from six import string_types
 from witheppy.eppyhelpers import iddhelpers

--- a/witheppy/eppyhelpers/extfields.py
+++ b/witheppy/eppyhelpers/extfields.py
@@ -14,7 +14,6 @@ from __future__ import unicode_literals
 
 
 # TODO : update the docstrings for nested=True
-# TODO : run lint
 
 # from six import StringIO
 # from six import string_types

--- a/witheppy/eppyhelpers/iddhelpers.py
+++ b/witheppy/eppyhelpers/iddhelpers.py
@@ -88,5 +88,4 @@ def beginextensible_at(objidd):
         for i, idditem in enumerate(objidd):
             if u'begin-extensible' in idditem:
                 return i
-                break
     return None


### PR DESCRIPTION
**Problem:** Both the functions work with flat lists. For the coordinates of a building surface it will return [2,3,4,22,33,44] instead of [(2,3,4),(22,33,44)]

**Solution:** Let extensiblefields2list() return a nested list list2extensiblefields() will work with nested or flat list tranparently. sample code would look like:

    points = extensiblefields2list(surface, nested=True)
    print(points)
    >> [(2,3,4),(22,33,44),(12,23,34)]

    newpoints = points + [(44,55,66)]
    print(newpoints)
    >> [(2, 3, 4), (22, 33, 44), (12, 23, 34), (44, 55, 66)]

    list2extensiblefields(surface, newpoints)
